### PR TITLE
Switch to GoogleCredentials class

### DIFF
--- a/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsStorageSettings.java
+++ b/src/main/java/io/aiven/elasticsearch/repositories/gcs/GcsStorageSettings.java
@@ -72,7 +72,7 @@ public class GcsStorageSettings {
 
     private static GoogleCredentials loadCredentials(final Settings settings) throws IOException {
         try (final var in = getStreamFor(CREDENTIALS_FILE_SETTING, settings)) {
-            return UserCredentials.fromStream(in);
+            return GoogleCredentials.fromStream(in);
         }
     }
 


### PR DESCRIPTION
Switch to GoogleCredentials instead of UserCredentials, for support all
credentionals settings for GCS