### PR TITLE
Bump jackson version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ allprojects {
         opensearchVersion = "2.9.0"
         // since jackson-core is in the main classpath
         // plz keep the same version as for OpenSearch
-        jacksonDatabind = "2.15.1"
+        jacksonDatabind = "2.15.2"
     }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 group "io.aiven"
-version=7.4.0-SNAPSHOT
+version=7.3.11


### PR DESCRIPTION
OpenSearch 2.9.0 moved to 2.15.2 so I suspect we need it too.
